### PR TITLE
[DM] Improve data recovery script

### DIFF
--- a/datamanager/legacy/recover_data.py
+++ b/datamanager/legacy/recover_data.py
@@ -14,9 +14,11 @@ Usage::
 The dataset-dir has to be the folder where schema.json and the input/ and output/ folders are located
 """
 import argparse
+import copy
 import json
 import os
 import re
+from collections import defaultdict
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -29,6 +31,8 @@ def main():
         export(Path(args.dataset_dir))
     except Exception as e:
         print(f"Export failed. Reason: \n {e}")
+        # Uncomment this to see the actual error and traceback - debugging purposes
+        # raise
 
 
 def export(dataset_path: Path):
@@ -44,7 +48,16 @@ def export(dataset_path: Path):
     print(f"Export - processing documents")
     for ofile in fnames:
         filename = ofile.name
-        doc = load_document(dataset_path, str(filename))
+        fname_key = os.path.split(filename)[1]
+        fname_key = re.sub(r"\.(box|raw)\.json$", "", fname_key)
+        try:
+            doc = load_document(dataset_path, str(filename), fname_key)
+            doc = export_normalize(doc)
+        except Exception as e:
+            print("Skipping invalid document:", fname_key)
+            # Uncomment this to see the actual error and traceback - debugging purposes
+            # raise e
+            continue
         doc["fname"] = str(filename)
         documents.append(doc)
 
@@ -61,7 +74,8 @@ def export(dataset_path: Path):
             export_zip.write(str(dataset_path.joinpath("input", doc["fname"])),
                              os.path.join("images", doc["fname"]))
             # -- update split_list
-            doc["subset"] = doc["subset"] if doc["subset"] not in ["", "none", None, "None"] else "TRAIN"
+            doc["subset"] = doc["subset"] if "subset" in doc and doc["subset"] not in ["", "none", None,
+                                                                                       "None"] else "TRAIN"
             split_list.append(doc["fname"] + "\t" + doc["subset"])
             if "language" in doc and type(doc["language"]) != str:
                 doc["language"] = ""
@@ -81,10 +95,7 @@ def export(dataset_path: Path):
     print(f"Exported file is available at: {export_zip_file}")
 
 
-def load_document(dspath: Path, fname: str):
-    fname_key = os.path.split(fname)[1]
-    fname_key = re.sub(r"\.(box|raw)\.json$", "", fname_key)
-
+def load_document(dspath: Path, fname: str, fname_key: str):
     fjson_output_path = dspath.joinpath(f"output/{fname_key}.json")
     fjson_input_path = dspath.joinpath(f"input/{fname_key}.box.json")
 
@@ -134,7 +145,11 @@ def load_document(dspath: Path, fname: str):
 
 def create_schema_data(dspath: Path) -> dict:
     with open(dspath.joinpath("schema.json")) as f:
-        schema_data = json.load(f)
+        try:
+            schema_data = json.load(f)
+        except json.JSONDecodeError:
+            print("WARNING: Schema file is invalid or corrupted")
+            return {}
     # remove hidden fields
     schema_data["extraction"] = [x for x in schema_data["extraction"] if not x.get("hidden")]
 
@@ -147,6 +162,80 @@ def create_schema_data(dspath: Path) -> dict:
             del item["section"]
 
     return schema_data
+
+
+def export_normalize(original_doc: dict) -> dict:
+    def renumber_lines(words):
+        # line assignment might not be contiguous
+        # we need to renumber the lines
+        prev_line = 0
+        line_ids = []
+        for word in words:
+            # make sure to fail gracefully when line is missing from the box
+            if "line" not in word:
+                word["line"] = prev_line
+            line_ids.append(word["line"])
+            prev_line = word["line"]
+        l1 = sorted(set(line_ids))
+        l2 = range(len(l1))
+        l12 = dict(zip(l1, l2))
+        for w in words:
+            w["line"] = l12[w["line"]]
+
+    doc = copy.deepcopy(original_doc)
+    words = doc.get("words", [])
+    renumber_lines(words)
+
+    # cleanup
+    for w in words:
+        if "vert_scaled" in w:
+            del w["vert_scaled"]
+        if "x_scaled" in w:
+            del w["x_scaled"]
+        if "y_scaled" in w:
+            del w["y_scaled"]
+        if "height_scaled" in w:
+            del w["height_scaled"]
+        if "tag" not in w:
+            w["tag"] = ""
+
+    # form string lines
+    line_boxes = defaultdict(list)
+    for w in words:
+        if "line" in w:
+            line_boxes[w["line"]].append(w)
+
+    words_sorted = []
+    words_sorted_grouped_per_line = []
+    lines = []
+    for line_id in sorted(line_boxes.keys()):
+        line = sorted(line_boxes[line_id], key=lambda w: w["boundingPoly"]["vertices"][0]["x"])
+        line_str = []
+        line_tags_str = []
+        for w in line:
+            line_str.append(w.get("description", ""))
+            if "tag" in w:
+                tag = w["tag"]
+                if tag in [None, "?"]:
+                    tag = ""
+                line_tags_str.append(tag)
+        lines.append(" ".join(line_str))
+        words_sorted += line
+        words_sorted_grouped_per_line.append(line)
+
+    rez = {
+        "fields": doc.get("fields", {}),
+        "items": doc.get("items", []),
+        "fname": doc["fname"],
+        "lines": lines,
+        "words": words_sorted_grouped_per_line,
+    }
+    if "manual_edit" in doc:
+        rez["manual_edit"] = doc["manual_edit"]
+    rez["schema"] = doc.get("schema", [])
+    rez["subset"] = doc.get("subset", None)
+
+    return rez
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
gather round and let me tell you a story about the good ol' DM

this PR fixes:
- skipping invalid files entirely, to make the final ZIP usable in a DM import
- adding some of the export normalization because some data was previously not added properly in the JSON and in some cases (the no longer supported .box.json and .raw.json) the ZIP was invlid for a DM import

Tried to keep the normalization at a minimum and only add the data required for a DM import and not the data ML requires for training, assuming this zip will only be used to be imported and re-exported from a new and clean DM session